### PR TITLE
fix: disable certificate verification in wget

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 # Credits - https://github.com/xorgram/xor
 
-wget https://github.com/ArnabXD/TGVCBot/releases/latest/download/archive.tgz
+wget --no-check-certificate https://github.com/ArnabXD/TGVCBot/releases/latest/download/archive.tgz
 tar xf archive.tgz
 rm archive.tgz
 


### PR DESCRIPTION
Wget by default does not have github's certificate, why not just bypass that?